### PR TITLE
Accept BigInt as input format

### DIFF
--- a/src/snf.jl
+++ b/src/snf.jl
@@ -186,7 +186,11 @@ function snf(M::AbstractMatrix{R}; inverse=true) where {R}
         else
             # Good pivot row for j-th column is the one
             # that have a smallest number of elements
-            rsize = typemax(R)
+	    if R == BigInt
+		rsize=Inf
+	    else
+		rsize = typemax(R)
+	    end
             for i in 1:rows
                 if D[i,j] != zero(R)
                     c = count(!iszero, view(D, i, :))


### PR DESCRIPTION
Thank @wildart for driving this forward.

I only have a quick comment. I was testing this algorithm for big matrices and I found the necessity of using the BigInt format to avoid a "DivideError: integer division error" in line 12 of bezout.jl (click [Issue](https://github.com/wildart/SmithNormalForm.jl/issues/5) for more information). 

The problem was that this format is not accepted in your code because "there is no method matching typemax(::Type{BigInt})". I have adapted the use of "typemax" in one part of the code to accept it.

I hope you find it useful.